### PR TITLE
set instancetype to t3.micro

### DIFF
--- a/lib/rds-initializer.ts
+++ b/lib/rds-initializer.ts
@@ -39,6 +39,7 @@ export class RdsStack extends Construct {
         username: "postgres",
         password: SecretValue.unsafePlainText("postgres"),
       },
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
       securityGroups: props.securityGroup,
       backupRetention: cdk.Duration.days(0),
       deleteAutomatedBackups: true,


### PR DESCRIPTION
tell it to use t3.micro instead of the default m5.large